### PR TITLE
Display user profile from nav

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import { Route, Routes, Link } from "react-router-dom";
 import { Register } from "./components/formComponents/Register";
 import { Login } from "./components/formComponents/Login";
 import { CreateProfile } from "./components/formComponents/CreateProfile"
+import DiscoverUserGetter from "./components/discover/DiscoverUserGetter";
 import UserProfile from "./components/user/UserProfile";
 // import { EditProfile } from "./components/user/EditProfile"
 // import { UserProfile } from "./components/user/UserProfile"
@@ -20,8 +21,9 @@ function App() {
         <Route path="/login" element={<Login />}></Route>
         <Route path="/register" element={<Register />}></Route>
         <Route path="/createprofile" element={<CreateProfile />}></Route>
-        <Route path="/main" element={<Main />}></Route>
-        <Route path="/userprofile" element={<UserProfile />}></Route>
+        <Route path="/main/*" element={<Main />}></Route>
+     
+      {/*   <Route path="/userprofile" element={<UserProfile />}></Route> */}
         {/* <Route path='/editprofile' element={<EditProfile/>}></Route> */}
 
       </Routes>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -47,7 +47,7 @@ export function Landing() {
           </Button>
         </Link>
     {/*     route to test navbar / bypass having to handle loggedin state right now  */}
-        <Link to="/main" style={{ textDecoration:"none",padding:"1rem", marginTop: "1rem", Justify: "Center"}}>
+        <Link to="/main/discover" style={{ textDecoration:"none",padding:"1rem", marginTop: "1rem", Justify: "Center"}}>
           <Button size="sm" variant="outlined">
             Go to main
           </Button>

--- a/src/components/MuseWindow.js
+++ b/src/components/MuseWindow.js
@@ -1,19 +1,24 @@
 import React from "react";
 import { Paper, Typography, Stack } from "@mui/material";
 import DiscoverUserGetter from "./discover/DiscoverUserGetter";
+import UserProfile from "./user/UserProfile";
+import { Route, Routes, Outlet } from "react-router-dom";
 
-export function MuseWindow({gradient}) {
-    let backgroundGradient = gradient
+export function MuseWindow({ gradient }) {
+  let backgroundGradient = gradient;
   return (
     <Paper
-    /*   elevation={8} */
+      /*   elevation={8} */
       sx={{ minHeight: "93vh", background: `${backgroundGradient}` }}
     >
-{/*       <Stack alignItems="center"> */}
+      {/*       <Stack alignItems="center"> */}
+      <Routes>
+        <Route path="/discover" element={<DiscoverUserGetter/>}/>
+        <Route path="/userprofile" element={<UserProfile/>}/>
+      </Routes>
+      <Outlet/>
 
-        <DiscoverUserGetter />
-      
-    {/*   </Stack> */}
+      {/*   </Stack> */}
     </Paper>
   );
 }

--- a/src/components/navbar/NavBar.js
+++ b/src/components/navbar/NavBar.js
@@ -1,6 +1,7 @@
 
 
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
@@ -94,13 +95,13 @@ export function NavBar() {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
-                /*blur is below this line */
-                sx={{backdropFilter: "blur(3px)"}}
                 open={Boolean(anchorEl)}
                 onClose={handleClose}
               >
                 {/*Only here for placeholder / testing, should .map over a "userPages" with props that provide reference to (or provide data of) "currentUser.userId". FYI: icons in MenuItem are possible as well */ }
-                <MenuItem onClick={handleClose}>Profile</MenuItem>
+                <Link to="/main/userprofile">
+                  <MenuItem onClick={handleClose}>Profile</MenuItem>
+                </Link>
                 <MenuItem onClick={handleClose}>Logout</MenuItem>
               </Menu>
             </div>

--- a/src/components/navbar/NavBar.js
+++ b/src/components/navbar/NavBar.js
@@ -1,22 +1,20 @@
-
-
-import * as React from 'react';
-import { Link } from 'react-router-dom';
-import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import AccountCircle from '@mui/icons-material/AccountCircle';
-import Switch from '@mui/material/Switch';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
-import MenuItem from '@mui/material/MenuItem';
-import Menu from '@mui/material/Menu';
-import WhatshotIcon from '@mui/icons-material/Whatshot';
-import ChatIcon from '@mui/icons-material/Chat';
-import { OpenChat } from './OpenChat';
+import * as React from "react";
+import { Link, Navigate } from "react-router-dom";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import MenuIcon from "@mui/icons-material/Menu";
+import AccountCircle from "@mui/icons-material/AccountCircle";
+import Switch from "@mui/material/Switch";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import MenuItem from "@mui/material/MenuItem";
+import Menu from "@mui/material/Menu";
+import WhatshotIcon from "@mui/icons-material/Whatshot";
+import ChatIcon from "@mui/icons-material/Chat";
+import { OpenChat } from "./OpenChat";
 
 //either above component or within, should only matter if there were multiple instances of the function component in the app. const dropDownPageArray = [ <ProfilePage/> , <LogOutButton/> ] ???
 // Pass UserID as props, store ID in a Ref (useRef hook)--get the page what it needs.
@@ -24,7 +22,7 @@ import { OpenChat } from './OpenChat';
 export function NavBar() {
   const [auth, setAuth] = React.useState(true);
   const [anchorEl, setAnchorEl] = React.useState(null);
-  const iconSizeBig = `sx={{ fontSize: "3.5rem" }}`
+  const iconSizeBig = `sx={{ fontSize: "3.5rem" }}`;
   const handleChange = (event) => {
     setAuth(event.target.checked);
   };
@@ -38,7 +36,7 @@ export function NavBar() {
   };
 
   return (
-    <Box sx={{ flexGrow: 1}}>
+    <Box sx={{ flexGrow: 1 }}>
       {/* <FormGroup>
         <FormControlLabel
           control={
@@ -53,14 +51,16 @@ export function NavBar() {
       </FormGroup> */}
       {/*we can do more positioning here, active sx override below right now, change flex property 
       We should establish breakpoints either in theme or inline*/}
-      <AppBar position="static" sx={{ alignItems: "center"}}>
-        <Toolbar variant="regular" >
-          
-         {/* auth condition !! */ }
+      <AppBar position="static" sx={{ alignItems: "center" }}>
+        <Toolbar variant="regular">
+          {/* auth condition !! */}
           {auth && (
             <div>
-              {/*IconButton re: Discover feature...*/}
+              {/*Link to discover view*/}
+
               <IconButton
+                component={Link}
+                to="/main/discover"
                 size="large"
                 aria-label="discover"
                 aria-controls="discover-appbar"
@@ -68,12 +68,13 @@ export function NavBar() {
                 /* onClick={} */
                 color="inherit"
               >
-                <WhatshotIcon sx={{ fontSize: "2.75rem" }}/>
+                <WhatshotIcon sx={{ fontSize: "2.75rem" }} />
               </IconButton>
+
               {/*OpenChat is here. Decide if we want a Dialog modal or to use react router*/}
               <OpenChat />
-               {/* User Dropdown IconButton */}
-               <IconButton
+              {/* User Dropdown IconButton */}
+              <IconButton
                 size="large"
                 aria-label="account of current user"
                 aria-controls="menu-appbar"
@@ -87,21 +88,25 @@ export function NavBar() {
                 id="menu-appbar"
                 anchorEl={anchorEl}
                 anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'right',
+                  vertical: "bottom",
+                  horizontal: "right",
                 }}
                 keepMounted
                 transformOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right',
+                  vertical: "top",
+                  horizontal: "right",
                 }}
                 open={Boolean(anchorEl)}
                 onClose={handleClose}
               >
-                {/*Only here for placeholder / testing, should .map over a "userPages" with props that provide reference to (or provide data of) "currentUser.userId". FYI: icons in MenuItem are possible as well */ }
-                <Link to="/main/userprofile">
-                  <MenuItem onClick={handleClose}>Profile</MenuItem>
-                </Link>
+                <MenuItem
+                  component={Link}
+                  to="/main/userprofile"
+                  onClick={handleClose}
+                >
+                  Profile
+                </MenuItem>
+
                 <MenuItem onClick={handleClose}>Logout</MenuItem>
               </Menu>
             </div>

--- a/src/components/user/UserProfile.js
+++ b/src/components/user/UserProfile.js
@@ -57,8 +57,6 @@ const UserProfile = () => {
 
   const content2 = <div>{"CLB"}</div>;
 
-  let backGrad = "linear-gradient(1deg, #00377C 40%, #F5F5F5)";
-
   return (
     <Stack alignItems="center">
       {/* <Typography

--- a/src/components/user/UserProfile.js
+++ b/src/components/user/UserProfile.js
@@ -1,5 +1,12 @@
 import React from "react";
-import {Box,FormGroup,TextField,Typography,Button,Paper} from "@mui/material";
+import {
+  Box,
+  FormGroup,
+  TextField,
+  Typography,
+  Button,
+  Paper,
+} from "@mui/material";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
 import CardMedia from "@mui/material/CardMedia";
@@ -15,11 +22,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
-import Chip from '@mui/material/Chip';
-import EditIcon from '@mui/icons-material/Edit';
+import Chip from "@mui/material/Chip";
+import EditIcon from "@mui/icons-material/Edit";
 
 import { useTheme } from "@mui/material";
-import { useNavigate } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 
 const UserProfile = () => {
   const theme = useTheme();
@@ -38,40 +45,23 @@ const UserProfile = () => {
     color: theme.palette.text.secondary,
   }));
 
-  const Root = styled('div')(({ theme }) => ({
-    width: '100%',
+  const Root = styled("div")(({ theme }) => ({
+    width: "100%",
     ...theme.typography.body2,
-    '& > :not(style) + :not(style)': {
+    "& > :not(style) + :not(style)": {
       marginTop: theme.spacing(2),
     },
   }));
 
-  const content = (
-    <div>
-      {'Pop'}
-    </div>
-  );
+  const content = <div>{"Pop"}</div>;
 
-  const content2 = (
-    <div>
-      {'CLB'}
-    </div>
-  );
+  const content2 = <div>{"CLB"}</div>;
 
   let backGrad = "linear-gradient(1deg, #00377C 40%, #F5F5F5)";
 
   return (
-    <div>
-      <Paper
-        elevation={8}
-        sx={{
-          minHeight: "100vh",
-          maxHeight: "100vh",
-          background: `${backGrad}`,
-        }}
-      >
-        <Box sx={{margin: "1rem"}}>
-           {/* <Typography
+    <Stack alignItems="center">
+      {/* <Typography
             sx={{
               textAlign: "center",
               padding: "2rem",
@@ -82,74 +72,69 @@ const UserProfile = () => {
           >
             MUSE
         </Typography> */}
-          <Card
-            sx={{
-              maxWidth: 500,
-              maxHeight: 920,
-              padding: "2rem",
-              margin: "2rem",
-              position: "absolute",
-            }}
+      <Card
+        sx={{
+          maxWidth: 500,
+          maxHeight: 920,
+          padding: "2rem",
+          margin: "2rem",
+          position: "absolute",
+        }}
+      >
+        <CardHeader
+          avatar={
+            <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">
+              C
+            </Avatar>
+          }
+          action={
+            <IconButton>
+              <EditIcon />
+            </IconButton>
+          }
+          title="Charmille"
+          subheader="New York City, New York"
+        />
+        <CardMedia
+          component="img"
+          height="360"
+          image="https://i.cbc.ca/1.6163000.1630614872!/fileImage/httpImage/drake-certified-lover-boy-album-art.jpeg"
+        />
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1a-content"
+            id="panel1a-header"
           >
-            <CardHeader
-              avatar={
-                <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">
-                  C
-                </Avatar>
-              }
+            <Typography>About Me</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
+              eget.
+            </Typography>
+          </AccordionDetails>
+        </Accordion>
 
-              
-              action={
-                <IconButton href> 
-                  <EditIcon />
-                </IconButton>
-              }
-              title="Charmille"
-              subheader="New York City, New York"
-            />
-            <CardMedia
-              component="img"
-              height="360"
-              image="https://i.cbc.ca/1.6163000.1630614872!/fileImage/httpImage/drake-certified-lover-boy-album-art.jpeg"
-            />
-            <Accordion>
-              <AccordionSummary
-                expandIcon={<ExpandMoreIcon />}
-                aria-controls="panel1a-content"
-                id="panel1a-header"
-              >
-                <Typography>About Me</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Typography>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                  Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
-                  eget.
-                </Typography>
-              </AccordionDetails>
-            </Accordion>
-
-            <Root>
-      <Divider sx={{padding: "1rem"}}>Favorite Genre</Divider>
-      {content}
-      <Divider>Favorite Album of All Time</Divider>
-      {content2}
-    </Root>
-
-            <Stack
-              direction="row"
-              divider={<Divider orientation="vertical" flexItem />}
-              spacing={2}
-              sx={{ margin: "1rem" }}
-            >
-              <Item>Music Item 1</Item>
-              <Item>Music Item 2</Item>
-              <Item>Music Item 3</Item>
-            </Stack>
-          </Card>
-        </Box>
-      </Paper>
-    </div>
+        <Root>
+          <Divider sx={{ padding: "1rem" }}>Favorite Genre</Divider>
+          {content}
+          <Divider>Favorite Album of All Time</Divider>
+          {content2}
+        </Root>
+        <Stack
+          direction="row"
+          divider={<Divider orientation="vertical" flexItem />}
+          spacing={2}
+          sx={{ margin: "1rem" }}
+        >
+          <Item>Music Item 1</Item>
+          <Item>Music Item 2</Item>
+          <Item>Music Item 3</Item>
+        </Stack>
+      </Card>
+    </Stack>
   );
 };
 

--- a/src/components/user/UserProfile.js
+++ b/src/components/user/UserProfile.js
@@ -73,10 +73,11 @@ const UserProfile = () => {
       <Card
         sx={{
           maxWidth: 500,
-          maxHeight: 920,
+        /*   maxHeight: 920, */
           padding: "2rem",
           margin: "2rem",
-          position: "absolute",
+   /*        position: "absolute", */
+          flexBasis: "auto"
         }}
       >
         <CardHeader


### PR DESCRIPTION
Link to userprofile on "profile" in navbar dropdown, renders userprofile card in musewindow @ <Outlet/>
Link to discover on whatshot icon in navbar, renders discover children in musewindow @ <Outlet/>
Updated path for "go to main" in <Landing/> to main/discover
Made userprofile responsive. 

Might be beneficial to have an "x" or "back" icon on userprofile card, and use router history to render whichever component was rendered in musewindow prior to userprofile. As of now, though, the user is able to navigate away from userprofile so this isn't breaking. 

can upload video as well.